### PR TITLE
0911 han Update 주문 상세 정보를 기반으로 상품 테이블 렌더링 수정

### DIFF
--- a/src/main/java/com/project/erpre/model/Customer.java
+++ b/src/main/java/com/project/erpre/model/Customer.java
@@ -1,6 +1,7 @@
 package com.project.erpre.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 
 import javax.persistence.*;
@@ -16,6 +17,7 @@ import java.util.List;
 @Getter
 @Setter
 @ToString
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Customer {
 
     @Id

--- a/src/main/java/com/project/erpre/model/Employee.java
+++ b/src/main/java/com/project/erpre/model/Employee.java
@@ -1,6 +1,7 @@
 package com.project.erpre.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,7 @@ import java.util.List;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
 public class Employee {
 
 //    @GeneratedValue(strategy = GenerationType.IDENTITY) 직원id는 자동증가하는 값이 아님

--- a/src/main/react/components/sales/Order.js
+++ b/src/main/react/components/sales/Order.js
@@ -31,7 +31,7 @@ function Order() {
     //상품
     const [selectedProductIndex, setSelectedProductIndex] = useState(null);
     //상품 인덱스 확인 후 등록 로직
-    
+
 
     // 페이지네이션 상태
     const [currentPageProduct, setCurrentPageProduct] = useState(1);


### PR DESCRIPTION
✔️ `fetchOrderDetail` 함수 업데이트: 주문 상세 및 상품 데이터를 처리하도록 수정.
✔️상품 테이블을 모드(생성/수정/보기)에 따라 주문 상세 정보 또는 상품 데이터를 표시하도록 조정.
✔️모드에 따라 입력 필드와 버튼의 조건부 렌더링 구현.
✔️ 상품 가격과 수량 입력 필드의 기본값 처리 수정.
✔️ 총 금액과 숨겨진 상품 코드의 올바른 표시 보장.
