### PR TITLE
0913 han Order 엔티티의 getProductNames 메서드  NullPointerException 해결

### DIFF
--- a/src/main/java/com/project/erpre/model/Order.java
+++ b/src/main/java/com/project/erpre/model/Order.java
@@ -1,6 +1,7 @@
 package com.project.erpre.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.project.erpre.model.Customer;
 import com.project.erpre.model.Employee;
@@ -10,8 +11,10 @@ import javax.persistence.*;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
 
 @Entity
 @Table(name = "m_order_h")
@@ -60,13 +63,16 @@ public class Order {
     private List<OrderDetail> orderDetails;
     // 주문과 상품 간의 관계
 
-    @JsonIgnore
+
     @Transient
     public List<String> getProductNames() {
+        if (orderDetails == null) {
+            return new ArrayList<>();
+        }
         return orderDetails.stream()
+                .filter(od -> od.getProduct() != null) // getProduct()가 null인지 확인
                 .map(od -> od.getProduct().getProductNm())
                 .collect(Collectors.toList());
-//        상품명을 리스트로 반환
     }
 
 }


### PR DESCRIPTION
기존 @JsonIgnore 어노테이션은 JSON 직렬화 및 역직렬화 과정에서 무시됨
 이는 클라이언트가 필드를 사용할 수 없는 문제 발생 
>>
 orderDetails가 null인 경우 빈 리스트를 반환하고, 
각 OrderDetail의 Product가 null인지 확인한 후 상품명을 반환 