### PR TITLE
0914 han 주문 목록에서 employeeId 필터링 오류 수정

### DIFF
--- a/src/main/java/com/project/erpre/service/OrderService.java
+++ b/src/main/java/com/project/erpre/service/OrderService.java
@@ -140,6 +140,4 @@ public class OrderService {
         orderRepository.deleteById(orderNo);
     }
 
-
-
 }


### PR DESCRIPTION
- 주문 데이터에서 employeeId를 올바르게 가져오도록 수정 (order.employee.employeeId 사용).
- employee 객체가 존재하는지 확인한 후 employeeId 접근 추가.
- 로그인한 직원과 관련된 주문만 필터링하도록 수정.
- SPA에서 관리자(admin)일 경우 전체 주문 목록 페이지로, 그 외의 멤버는 담당 주문 목록 페이지로 렌더링하도록 조건 추가.
