### PR TITLE
0916 han 주문 목록 / 주문 승인 페이지 구현 완료: 필터링, 페이징, 상태 업데이트 기능 포함

### DIFF
--- a/src/main/java/com/project/erpre/controller/OrderController.java
+++ b/src/main/java/com/project/erpre/controller/OrderController.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -143,6 +144,27 @@ public class OrderController {
         return orderService.getOrdersByOrderDate(orderDate);
     }
 
+    // 주문 상태 업데이트 엔드포인트
+    @PatchMapping("/updateStatus/{orderNo}")
+    public ResponseEntity<?> updateOrderStatus(@PathVariable Integer orderNo, @RequestBody OrderDTO orderDTO) {
+        try {
+            // 주문 엔티티를 조회합니다.
+            Order existingOrder = orderService.getOrderById(orderNo);
+            if (existingOrder == null) {
+                return new ResponseEntity<>("주문을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+            }
 
+            // 상태를 DTO에서 가져와서 업데이트합니다.
+            existingOrder.setOrderHStatus(orderDTO.getOrderHStatus());
+            existingOrder.setOrderHUpdateDate(LocalDateTime.now());
+
+            // 엔티티를 업데이트하고 저장합니다.
+            Order updatedOrder = orderService.updateOrder(existingOrder);
+            return new ResponseEntity<>(updatedOrder, HttpStatus.OK);
+        } catch (Exception e) {
+            logger.error("주문 상태 업데이트 중 오류 발생: ", e);
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 
 }

--- a/src/main/java/com/project/erpre/repository/OrderRepository.java
+++ b/src/main/java/com/project/erpre/repository/OrderRepository.java
@@ -19,7 +19,7 @@ public interface OrderRepository extends JpaRepository<Order, Integer> {
     //날짜로 주문 목록 조회
     List<Order> findByOrderHInsertDateContaining(String orderHInsertDate);
 
-
-
+    // 리스트에 포함된 모든 주문 조회
+    List<Order> findAllByOrderNoIn(List<Integer> orderNos);
 
 }

--- a/src/main/java/com/project/erpre/service/OrderService.java
+++ b/src/main/java/com/project/erpre/service/OrderService.java
@@ -140,4 +140,8 @@ public class OrderService {
         orderRepository.deleteById(orderNo);
     }
 
+    public Order updateOrder(Order order) {
+        return orderRepository.save(order);
+    }
+
 }

--- a/src/main/resources/static/css/sales/OrderList.css
+++ b/src/main/resources/static/css/sales/OrderList.css
@@ -47,6 +47,15 @@
 .date-separator {
     font-size: 1.5rem; /* 기호 크기 조절 */
 }
+.checkbox-input{
+    width: 50px;
+
+}
+.approve-button{
+
+}
+
+
 
 /* 검색 필터*/
 .filter-section {


### PR DESCRIPTION
- `OrderList/OrderListAssigned` 컴포넌트 구현 완료:
  - **데이터 조회:** 서버에서 주문 목록과 직원 정보를 가져오는 기능 추가.
  - **필터링 기능:** 고객사, 주문 등록일, 상태, 물품 리스트, 담당자별로 주문을 필터링할 수 있는 기능 구현.
  - **페이징 기능:** 페이지 당 항목 수 조정, 페이지 이동 버튼 (처음, 이전, 다음, 끝) 추가.
  - **주문 상태 업데이트:** 권한을 가진 직원이 선택한 주문의 상태를 승인하거나 반려할 수 있는 기능 추가.
  - **날짜 범위 필터링:** 특정 날짜 범위 내의 주문만 필터링할 수 있는 기능 구현.
  - **UI 개선:** 검색 기능 추가, 상태 매핑 기능, 레이아웃 및 스타일 개선.
  - **오류 처리:** 데이터 조회 실패나 작업 오류 시 알림 및 오류 메시지 표시.
  - **역할 기반 접근:** 관리자와 직원의 화면을 구분하여 관리자에게 모든 주문과 배치 작업을 허용.

- 페이징 컨트롤 추가: 페이지 이동 및 페이지 번호 입력 필드 포함.
- CSS 스타일링 적용으로 레이아웃 및 시각적 일관성 확보.
- 상태 업데이트 및 데이터 처리 로직을 통한 정확한 상태 관리.

해당 커밋으로 주문 목록 / 주문 승인 페이지의 핵심 기능 구현이 모두 완료되었습니다.

<div align="center">

![20200606081201_txlsvnkh](https://github.com/user-attachments/assets/66e5155e-e136-4ecc-b16d-ba070103a293)


 </div>
