### PR TITLE
0916 han 특정 모드 및 역할에 따른 UI 변경 및 SideBar 경로 수정

### DIFF
--- a/src/main/react/layout/Sidebar.js
+++ b/src/main/react/layout/Sidebar.js
@@ -94,7 +94,7 @@ function Sidebar({currentMenu}) {
                         </li>
                         <li className={currentMenu === 'orderRegisterApproval' ? 'active' : ''}>
                             <a href="#"
-                               onClick={() => handleSubMenuClick('orderRegisterApproval', '/orderRegisterApproval')}>주문 등록 승인</a>
+                               onClick={() => handleSubMenuClick('orderRegisterApproval', '/orderList?mode=Assigned')}>주문 등록 승인</a>
                         </li>
                         <li className={currentMenu === 'orderReport' ? 'active' : ''}>
                             <a href="#" onClick={() => handleSubMenuClick('orderReport', '/orderReport')}>영업 실적 보고서</a>


### PR DESCRIPTION
- itsAssignedMode와 role이 'admin'일 때만 체크박스를 표시하도록 조건 추가
- itsAssignedMode와 role이 'admin'일 때만 빈 <td>를 추가하여 UI 통일
- itsAssignedMode와 role이 'admin'일 때 제목을 '주문등록승인'으로 변경, 그 외에는 기존 제목 유지
- itsAssignedMode와 role이 'admin'일 때 Layout 컴포넌트의 currentMenu를 'orderRegisterApproval'로 변경
- 'admin'이 아닌 'role'이 링크 또는 메뉴로 접근할 때 , main으로 Access 거부