### PR TITLE
0926 han MainPage 대시보드 데이터 가져오기 및 오류 처리 개선

### DIFF
--- a/src/main/java/com/project/erpre/controller/EmployeeController.java
+++ b/src/main/java/com/project/erpre/controller/EmployeeController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpSession;
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,5 +143,23 @@ public class EmployeeController {
     public ResponseEntity<Boolean> checkEmployeeId(@RequestParam String employeeId) {
         boolean exists = employeeService.existsByEmployeeId(employeeId);
         return ResponseEntity.ok(exists);
+    }
+
+    // 전체 직원 수를 반환하는 API
+    @GetMapping("/employeeCount")
+    public long getTotalEmployeeCount() {
+        return employeeService.getTotalEmployeeCount();
+    }
+
+    @GetMapping("/employeeRecentCount")
+    public ResponseEntity<Long> getRecentHiresCount() {
+        try {
+            int days = 30; // 최근 30일
+            long recentHiresCount = employeeService.getRecentHiresCount(days); // 서비스 호출
+            return ResponseEntity.ok(recentHiresCount); // 성공적으로 직원 수 반환
+        } catch (Exception e) {
+            // 예외가 발생한 경우 500 오류와 함께 null 응답
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
     }
 }

--- a/src/main/java/com/project/erpre/controller/OrderDetailController.java
+++ b/src/main/java/com/project/erpre/controller/OrderDetailController.java
@@ -89,4 +89,12 @@ public class OrderDetailController {
             return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    @GetMapping("/api/totalSales")
+    public ResponseEntity<Long> getTotalSales() {
+        Long totalSales = orderDetailService.getTotalOrderQuantity();
+        return ResponseEntity.ok(totalSales);
+    }
+
+
 }

--- a/src/main/java/com/project/erpre/controller/ProductController.java
+++ b/src/main/java/com/project/erpre/controller/ProductController.java
@@ -154,5 +154,22 @@ public class ProductController {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
         }
     }
+
+
+    @GetMapping("/productCounts")
+    public ResponseEntity<Map<String, Long>> getProductCounts() {
+        try {
+            long totalProductCount = productService.getTotalProductCount();
+            long recentProductCount = productService.getRecentProductCount();
+            Map<String, Long> productCounts = new HashMap<>();
+            productCounts.put("totalProductCount", totalProductCount);
+            productCounts.put("recentProductCount", recentProductCount);
+            return ResponseEntity.ok(productCounts);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        }
+    }
+
+
 }
 

--- a/src/main/java/com/project/erpre/repository/EmployeeRepository.java
+++ b/src/main/java/com/project/erpre/repository/EmployeeRepository.java
@@ -4,8 +4,12 @@ import com.project.erpre.model.Employee;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,4 +35,12 @@ public interface EmployeeRepository extends JpaRepository<Employee, String> {
     List<Employee> findByEmployeeDeleteYn(String employeeDeleteYn); //N인것만
 
     boolean existsByEmployeeId(String employeeId); //삭제 된 것도 포함해서 중복ID 가입 불가
+
+    // 전체 직원 수
+    long count();
+
+    // 최근 채용된 직원 수를 특정 기간 내에 조회
+    @Query("SELECT COUNT(e) FROM Employee e WHERE e.employeeInsertDate >= CURRENT_DATE - 30")
+    long countRecentHires(int days);
+
 }

--- a/src/main/java/com/project/erpre/repository/OrderDetailRepository.java
+++ b/src/main/java/com/project/erpre/repository/OrderDetailRepository.java
@@ -2,6 +2,7 @@ package com.project.erpre.repository;
 
 import com.project.erpre.model.OrderDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,5 +11,8 @@ import java.util.List;
 public interface OrderDetailRepository extends JpaRepository<OrderDetail, Integer> {
 
    List<OrderDetail> findByOrderOrderNo(Integer orderNo);
+
+   @Query("SELECT SUM(o.orderDQty) FROM OrderDetail o")
+   Long sumOrderDQty(); // 모든 orderDQty의 합계를 반환하는 메서드
 
 }

--- a/src/main/java/com/project/erpre/repository/OrderRepository.java
+++ b/src/main/java/com/project/erpre/repository/OrderRepository.java
@@ -2,8 +2,13 @@ package com.project.erpre.repository;
 
 import com.project.erpre.model.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -21,5 +26,19 @@ public interface OrderRepository extends JpaRepository<Order, Integer> {
 
     // 리스트에 포함된 모든 주문 조회
     List<Order> findAllByOrderNoIn(List<Integer> orderNos);
+
+    //오더 전체 수량
+    @Query("SELECT COUNT(o) FROM Order o")
+    long countOrders();
+
+    // 특정 상태에 따른 주문 수를 계산하는 메서드
+    long countByOrderHStatus(String orderHStatus);
+
+    @Query("SELECT SUM(o.orderHTotalPrice) FROM Order o WHERE o.orderHStatus = 'approved' AND o.orderHInsertDate >= :thirtyDaysAgo")
+    BigDecimal sumApprovedOrdersLastMonth(@Param("thirtyDaysAgo") LocalDateTime thirtyDaysAgo);
+
+    @Query("SELECT SUM(o.orderHTotalPrice) FROM Order o WHERE o.orderHStatus = 'ing' AND o.orderHInsertDate >= :thirtyDaysAgo")
+    BigDecimal sumDeniedOrdersLastMonth(@Param("thirtyDaysAgo") LocalDateTime thirtyDaysAgo);
+
 
 }

--- a/src/main/java/com/project/erpre/repository/ProductRepository.java
+++ b/src/main/java/com/project/erpre/repository/ProductRepository.java
@@ -43,6 +43,12 @@ public interface ProductRepository extends JpaRepository<Product, String>, Produ
             @Param("topCategory") Integer topCategory,
             @Param("middleCategory") Integer middleCategory,
             @Param("lowCategory") Integer lowCategory);
+
+    @Query("SELECT COUNT(p) FROM Product p")
+    long countAllProducts();
+
+    @Query("SELECT COUNT(p) FROM Product p WHERE p.productInsertDate >= CURRENT_DATE - 3")
+    long countRecentProducts();
 }
 
 

--- a/src/main/java/com/project/erpre/service/EmployeeService.java
+++ b/src/main/java/com/project/erpre/service/EmployeeService.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -134,4 +136,16 @@ public class EmployeeService {
     public boolean existsByEmployeeId(String employeeId) {
         return employeeRepository.existsById(employeeId);
     }
+
+
+    // 전체 직원 수 가져오기
+    public long getTotalEmployeeCount() {
+        return employeeRepository.count();
+    }
+
+    // 최근 채용된 직원 수 가져오기
+    public long getRecentHiresCount(int days) {
+        return employeeRepository.countRecentHires(days);
+    }
+
 }

--- a/src/main/java/com/project/erpre/service/OrderDetailService.java
+++ b/src/main/java/com/project/erpre/service/OrderDetailService.java
@@ -142,5 +142,9 @@ public class OrderDetailService {
         return orderDetailRepository.findByOrderOrderNo(orderNo);
     }
 
+    public Long getTotalOrderQuantity() {
+        return orderDetailRepository.sumOrderDQty(); // 모든 판매량을 합산한 값 반환
+    }
+
 
 }

--- a/src/main/java/com/project/erpre/service/OrderService.java
+++ b/src/main/java/com/project/erpre/service/OrderService.java
@@ -8,7 +8,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -190,6 +193,44 @@ public class OrderService {
 
         logger.info("상세 주문 {} 삭제 완료", detailId); // 삭제 완료 로그
     }
+
+    
+    //전체 수량 카운트 코드
+    public long getTotalOrderCount() {
+        return orderRepository.countOrders();
+    }
+
+    // 특정 상태에 따른 주문 수 계산
+    public long countOrdersByStatus(String status) {
+        return orderRepository.countByOrderHStatus(status);
+    }
+
+    public BigDecimal getApprovedTotalAmount() {
+        LocalDate thirtyDaysAgo = LocalDate.now().minusDays(30);
+        LocalDateTime thirtyDaysAgoDateTime = thirtyDaysAgo.atStartOfDay(); // LocalDateTime으로 변환
+        return orderRepository.sumApprovedOrdersLastMonth(thirtyDaysAgoDateTime);
+    }
+
+    public BigDecimal getDeniedTotalAmount() {
+        LocalDate thirtyDaysAgo = LocalDate.now().minusDays(30);
+        LocalDateTime thirtyDaysAgoDateTime = thirtyDaysAgo.atStartOfDay(); // LocalDateTime으로 변환
+        return orderRepository.sumDeniedOrdersLastMonth(thirtyDaysAgoDateTime);
+    }
+
+    public String getSettlementDeadline() {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime deadline;
+
+        if (now.getDayOfMonth() > 15) {
+            deadline = LocalDateTime.of(now.getYear(), now.getMonth().plus(1), 15, 0, 0);
+        } else {
+            deadline = LocalDateTime.of(now.getYear(), now.getMonth(), 15, 0, 0);
+        }
+
+        return deadline.format(DateTimeFormatter.ofPattern("yyyy년 M월 d일")); // "2024년 9월 15일" 형식
+    }
+
+
 
 
 

--- a/src/main/java/com/project/erpre/service/ProductService.java
+++ b/src/main/java/com/project/erpre/service/ProductService.java
@@ -207,6 +207,15 @@ public class ProductService {
                 .build();
     }
 
+    public long getTotalProductCount() {
+        return productRepository.countAllProducts();
+    }
+
+    public long getRecentProductCount() {
+        return productRepository.countRecentProducts();
+    }
+
+
 
 }
 

--- a/src/main/react/components/main/Main.js
+++ b/src/main/react/components/main/Main.js
@@ -6,138 +6,123 @@ import '../../../resources/static/css/common/Main.css';
 import axios from 'axios';
 
 function Main() {
-
     const [totalCustomers, setTotalCustomers] = useState(0);
     const [recentCustomers, setRecentCustomers] = useState([]);
     const [renewalCustomers, setRenewalCustomers] = useState([]);
-    const [modalContent, setModalContent] = useState(null);
-    const [isModalOpen, setIsModalOpen] = useState(false);
-    const [modalType, setModalType] = useState(null); // 모달 타입 추가
+    const [totalEmployees, setTotalEmployees] = useState(0);
+    const [recentHiresCount, setRecentHiresCount] = useState(0);
+    const [orderCount, setOrderCount] = useState(0);
+    const [orderStatusCount, setOrderStatusCount] = useState({
+        ingCount: 0,
+        approvedCount: 0,
+        deniedCount: 0,
+    });
+    const [totalProductCount, setTotalProductCount] = useState(0);
+    const [recentProductCount, setRecentProductCount] = useState(0);
+    const [totalSales, setTotalSales] = useState(0);
+    const [settlementInfo, setSettlementInfo] = useState({
+        approvedTotal: 0,
+        deniedTotal: 0,
+        settlementDeadline: '',
+    });
 
     useEffect(() => {
-        // 총 고객사 수 가져오기
-        axios.get('/api/customer/count')
-            .then(response => {
-                setTotalCustomers(response.data);
-            })
-            .catch(error => {
-                console.error("총 고객사 수를 가져오는 중 오류 발생:", error);
-                window.showToast("총 고객사 수를 가져오는 데 실패했습니다.", 'error');
-            });
+        const fetchData = async () => {
+            try {
+                // 전체 주문 수, 상태별 주문 각각
+                const orderStatusResponse = await axios.get('/api/order/status/count');
+                const { ingCount, approvedCount, deniedCount } = orderStatusResponse.data;
+                setOrderStatusCount({ ingCount, approvedCount, deniedCount });
+                setOrderCount(ingCount + approvedCount + deniedCount);
 
-        // 최근 신규 고객 가져오기
-        axios.get('/api/customer/recent')
-            .then(response => {
-                setRecentCustomers(response.data);
-            })
-            .catch(error => {
-                console.error("최근 신규 고객을 가져오는 중 오류 발생:", error);
-                window.showToast("최근 신규 고객을 가져오는 데 실패했습니다.", 'error');
-            });
+                // 전체 직원 수 가져오기
+                const employeesResponse = await axios.get('/api/employeeCount');
+                setTotalEmployees(employeesResponse.data);
 
-        // 계약 갱신 예정 고객 가져오기
-        axios.get('/api/customer/renewals')
-            .then(response => {
-                setRenewalCustomers(response.data);
-            })
-            .catch(error => {
-                console.error("계약 갱신 예정 고객을 가져오는 중 오류 발생:", error);
-                window.showToast("계약 갱신 예정 고객을 가져오는 데 실패했습니다.", 'error');
-            });
+                // 최근 채용 직원 수
+                const recentHiresResponse = await axios.get('/api/employeeRecentCount');
+                setRecentHiresCount(recentHiresResponse.data);
+
+                // 총 고객사 수 가져오기
+                const customersResponse = await axios.get('/api/customer/count');
+                setTotalCustomers(customersResponse.data);
+
+                // 상품 수를 가져오기
+                const productCountsResponse = await axios.get('/api/products/productCounts');
+                const { totalProductCount, recentProductCount } = productCountsResponse.data;
+                setTotalProductCount(totalProductCount);
+                setRecentProductCount(recentProductCount);
+
+                // 판매량 가져오기
+                const totalSalesResponse = await axios.get('/api/totalSales');
+                setTotalSales(totalSalesResponse.data || 0);
+
+                // 정산 정보 가져오기
+                const settlementResponse = await axios.get('/api/order/settlement');
+                setSettlementInfo(settlementResponse.data);
+
+                // 최근 신규 고객 가져오기
+                const recentCustomersResponse = await axios.get('/api/customer/recent');
+                setRecentCustomers(recentCustomersResponse.data);
+
+                // 계약 갱신 예정 고객 가져오기
+                const renewalCustomersResponse = await axios.get('/api/customer/renewals');
+                setRenewalCustomers(renewalCustomersResponse.data);
+
+            } catch (error) {
+                console.error("데이터를 가져오는 중 오류 발생:", error);
+                window.showToast("데이터를 가져오는 데 실패했습니다.", 'error');
+            }
+        };
+
+        fetchData();
     }, []);
-
-    const openModal = (type) => {
-        setModalType(type);
-        setIsModalOpen(true);
-    };
-
-    const closeModal = () => {
-        setIsModalOpen(false);
-        setModalType(null);
-    };
-
-    // 모달 내용 렌더링 함수
-    const renderModalContent = () => {
-        if (modalType === 'total') {
-            return (
-                <div>
-                    <h2>총 고객사 수</h2>
-                    <p>총 고객사 수는 {totalCustomers}개 입니다.</p>
-                </div>
-            );
-        } else if (modalType === 'recent') {
-            return (
-                <div>
-                    <h2>최근 신규 고객</h2>
-                    <ul>
-                        {recentCustomers.map(customer => (
-                            <li key={customer.customerNo}>{customer.customerName}</li>
-                        ))}
-                    </ul>
-                </div>
-            );
-        } else if (modalType === 'renewal') {
-            return (
-                <div>
-                    <h2>계약 갱신 예정 고객</h2>
-                    <ul>
-                        {renewalCustomers.map(customer => (
-                            <li key={customer.customerNo}>{customer.customerName}</li>
-                        ))}
-                    </ul>
-                </div>
-            );
-        } else {
-            return null;
-        }
-    };
 
     return (
         <Layout currentMenu="main">
             <main className="main-content dashboard-container">
                 <div className="card card-large">
-                    <h3>인사 관리</h3>
+                    <h3><i className="bi bi-people-fill"></i> 인사 관리</h3>
                     <div className="info-group">
-                        <p>전체 직원 수: 120명</p>
-                        <p>최근 채용: 5명</p>
-                        <p>퇴사 예정: 2명</p>
+                        <p>전체 직원 수: {totalEmployees}명</p>
+                        <p>최근 채용: {recentHiresCount}명</p>
                     </div>
                 </div>
                 <div className="card card-large">
-                    <h3>영업 관리</h3>
+                    <h3><i className="bi bi-bar-chart-line-fill"></i> 영업 관리</h3>
                     <div className="info-group">
-                        <p>결재중: 0건</p>
-                        <p>결재완료: 0건</p>
-                        <p>반려: 0건</p>
+                        <p>총 주문건 수: {orderCount}건</p>
+                        <p>결재중: {orderStatusCount.ingCount}건</p>
+                        <p>결재완료: {orderStatusCount.approvedCount}건</p>
+                        <p>반려: {orderStatusCount.deniedCount}건</p>
                     </div>
                 </div>
                 <div className="card card-large">
-                    <h3>고객 관리</h3>
+                    <h3><i className="bi bi-building"></i> 고객 관리</h3>
                     <div className="info-group">
-                        <p onClick={() => openModal('total')} style={{ cursor: 'pointer', color: 'blue' }}> 총 고객사 수: {totalCustomers}개 </p>
-                        <p onClick={() => openModal('recent')} style={{ cursor: 'pointer', color: 'blue' }}> 최근 신규 고객: {recentCustomers.length}개</p>
-                        <p onClick={() => openModal('renewal')} style={{ cursor: 'pointer', color: 'blue' }}> 계약 갱신 예정: {renewalCustomers.length}개 </p>
+                        <p> 총 고객사 수: {totalCustomers}개 </p>
+                        <p> 최근 신규 고객: {recentCustomers.length}개</p>
+                        <p> 계약 갱신 예정: {renewalCustomers.length}개 </p>
                     </div>
                 </div>
                 <div className="card card-full">
-                    <h3>상품관리</h3>
+                    <h3><i className="bi bi-box-seam"></i> 상품 관리</h3>
                     <div className="info-group">
-                        <p>재고 현황: 1200개</p>
-                        <p>신상품 등록: 8개</p>
-                        <p>최근 판매량: 450개</p>
-                        {/*    넣어도 될 것 같기도 하구요?*/}
+                        <p>상품 전체 수량: {totalProductCount}개</p>
+                        <p>신상품 등록: {recentProductCount}개</p>
+                        <p>최근 판매량: {totalSales}개</p>
                     </div>
                 </div>
                 <div className="card">
-                    <h3>정산관련 안내</h3>
+                    <h3><i className="bi bi-cash-coin"></i> 정산 관련 안내</h3>
                     <div className="info-group">
-                        <p>정산금액: ₩2,500,000</p>
-                        <p>정산 마감일: 2024년 9월 15일</p>
-                        <p>미수금: ₩300,000</p>
+                        <p>정산금액: ₩{(settlementInfo.approvedTotal || 0).toLocaleString()}</p>
+                        <p>정산 마감일: {settlementInfo.settlementDeadline || '정보 없음'}</p>
+                        <p>미수금: ₩{(settlementInfo.deniedTotal || 0).toLocaleString()}</p>
                     </div>
                 </div>
                 <div className="card">
-                    <h3>공지사항</h3>
+                    <h3><i className="bi bi-megaphone-fill"></i> 공지사항</h3>
                     <div className="info-group">
                         <p>새로운 이벤트: 가을 세일</p>
                         <p>공지사항 업데이트: 2024년 9월 1일</p>
@@ -145,25 +130,15 @@ function Main() {
                     </div>
                 </div>
                 <div className="card">
-                    <h3>영업 실적 보고서</h3>
+                    <h3><i className="bi bi-graph-up-arrow"></i> 영업 실적 보고서</h3>
                     <div className="info-group">
                         <p>총 매출: ₩5,000,000</p>
                         <p>총 주문 수: 150건</p>
                         <p>월간 목표 달성율: 85%</p>
                     </div>
                 </div>
-
-                {/* 고객관리 모달 */}
-                {isModalOpen && (
-                    <div className="modal-overlay" onClick={closeModal}>
-                        <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-                            <span className="close-button" onClick={closeModal}>&times;</span>
-                            {renderModalContent()}
-                        </div>
-                    </div>
-                )}
             </main>
-        </Layout >
+        </Layout>
     );
 }
 

--- a/src/main/react/components/sales/OrderList.js
+++ b/src/main/react/components/sales/OrderList.js
@@ -518,10 +518,10 @@ function OrderList() {
                             {itsAssignedMode && role === 'admin' && (
                                 <>
                                     <button className="box color" onClick={handleApproveSelectedOrders}>
-                                        결재승인
+                                        결재
                                     </button>
                                     <button className="box" onClick={handleDeniedSelectedOrders}>
-                                        반려요청
+                                        반려
                                     </button>
                                 </>
                             )}


### PR DESCRIPTION
#### API 호출: 여러 API를 통해 대시보드에 필요한 데이터(주문 상태, 직원 수, 고객 수, 상품 수, 매출 등)를 가져오는 기능을 구현.

- 정산 정보 API 호출 후, 응답 데이터의 null 체크를 추가하여 오류 발생 방지.
- 정산 금액 및 미수금 표시 시 toLocaleString() 메서드를 호출하기 전에 데이터가 null이 아닌지 확인하는 로직 추가.
- 정산 마감일의 기본값을 설정하여, 해당 데이터가 없을 경우에도 사용자에게 유의미한 정보 제공.

- 각 카드 컴포넌트 내의 데이터를 표시하는 방식 개선으로 UI/UX 향상.
- 상태별 주문 수, 직원 수, 고객사 수 등의 정보를 직관적으로 보여주는 레이아웃 개선.