### PR TITLE
0927 han 주문 반려 시 수정 후 재결재 요청 기능 추가 및 주문 등록 시 중복 요청 방지 로직 구현

### DIFF
--- a/src/main/react/components/main/Main.js
+++ b/src/main/react/components/main/Main.js
@@ -31,6 +31,7 @@ function Main() {
 
     useEffect(() => {
         const fetchData = async () => {
+            const startTime = performance.now(); // 요청 시작 시간
             try {
                 const [
                     orderStatusResponse,
@@ -76,6 +77,11 @@ function Main() {
                 setRecentCustomers(recentCustomersResponse.data);
                 setRenewalCustomers(renewalCustomersResponse.data);
                 setDeletedEmployees(deletedEmployeesResponse.data);
+
+                const endTime = performance.now(); // 요청 종료 시간
+                const duration = endTime - startTime; // 소요 시간 계산
+
+                console.log(`요청 소요 시간: ${duration.toFixed(2)}ms`);
 
             } catch (error) {
                 console.error("데이터를 가져오는 중 오류 발생:", error);

--- a/src/main/react/components/sales/Order.js
+++ b/src/main/react/components/sales/Order.js
@@ -37,7 +37,7 @@ function Order() {
 
         if (selectedProductIndex !== null) {
 
-            if (isEditMode) {
+            if (isEditMode || isResubmitMode) {
                 const updatedOrderDetails = [...orderDetails];
                 updatedOrderDetails[selectedProductIndex] = {
                     ...updatedOrderDetails[selectedProductIndex],
@@ -190,6 +190,7 @@ function Order() {
         isCreateMode,  // 현재 주문이 등록 모드인지 확인
         isEditMode,    // 현재 주문이 수정 모드인지 확인
         isDetailView,  // 현재 주문이 상세보기 모드인지 확인
+        isResubmitMode, // 반려 주문을 수정 모드에서 등록하는지 확인
 
         // 주문 번호 관련 상태
         orderNo,       // 현재 주문 번호
@@ -214,6 +215,7 @@ function Order() {
         // 주문 생성 및 수정 함수
         handleSubmit,   // 주문 생성 처리 함수
         handleEdit,     // 주문 수정 처리 함수
+        handleResubmit,
 
         // 날짜 관련 함수
         formatDateForInput,  // 날짜를 yyyy-mm-dd 형식으로 변환하는 함수
@@ -233,13 +235,13 @@ function Order() {
             <main className="main-content menu_order">
                 <div className="menu_title">
                     <div className="sub_title">영업 관리</div>
-                    <div className="main_title">{isCreateMode ? '주문 등록' : isEditMode ? '주문 수정' : '주문 상세보기'}</div>
+                    <div className="main_title">{isCreateMode ? '주문 등록' : isEditMode || isResubmitMode ? '주문 수정' : '주문 상세보기'}</div>
                 </div>
                 <div className="menu_content">
                     <div className="search_wrap">
                         <div className="left">
                             <div className="form-row">
-                                {orderNo && (
+                                {orderNo && !isResubmitMode && (
                                     <div className="form-group">
                                         <label>주문번호</label>
                                         <input type="text" value={orderNo} readOnly className="box readonly" />
@@ -255,13 +257,13 @@ function Order() {
                                     <button
                                         className="search-button"
                                         onClick={() => setCustomerModalOpen(true)}
-                                        style={{ display: !isEditMode && !isCreateMode ? 'none' : 'block' }}
+                                        style={{ display: !isEditMode && !isCreateMode && !isResubmitMode ? 'none' : 'block' }}
                                     >
                                         <i className="bi bi-search"></i>
                                     </button>
                                 </div>
 
-                                {!isCreateMode && (
+                                {!isCreateMode && !isResubmitMode && (
                                     <>
                                         <div className="form-group">
                                             <label>물품 총액</label>
@@ -364,8 +366,9 @@ function Order() {
                                         placeholder="고객사 선택" readOnly />
                                 </div>
 
-                                {!isCreateMode &&
+                                {!isCreateMode && !isResubmitMode &&(
                                     <div className="form-group">
+
                                         <label>현재 주문 상태</label>
                                         <span className={`order-status ${orderHStatus}`}>
                                             {/* 상태에 따른 한글로 텍스트 변경 */}
@@ -374,17 +377,20 @@ function Order() {
                                             {orderHStatus === 'approved' && '결재완료'}
                                         </span>
                                     </div>
-                                }
+                                )}
                             </div>
 
                         </div>
                         <div className="right">
-                            {/* 제품 추가 버튼 - 생성 모드 또는 수정 모드에서만 표시 */}
-                            {(isCreateMode || isEditMode) && customerData.customerName && orderHStatus !== 'approved' && orderHStatus !== 'denied' && (
-                                <button className="box color" onClick={isCreateMode ? addProductRow : editProductRow}>
-                                    <i className="bi bi-plus-circle"></i> 추가하기
-                                </button>
-                            )}
+                            {/* 제품 추가 버튼 - 생성 모드 또는 수정 모드(재생성모드) 에서만 표시 */}
+                            {(isCreateMode || isEditMode || isResubmitMode) &&
+                                customerData.customerName &&
+                                orderHStatus !== 'approved' &&
+                                ((isResubmitMode && orderHStatus === 'denied') || orderHStatus !== 'denied') && (
+                                    <button className="box color" onClick={isCreateMode ? addProductRow : editProductRow}>
+                                        <i className="bi bi-plus-circle"></i> 추가하기
+                                    </button>
+                                )}
                         </div>
                     </div>
                     <div className="table_wrap">
@@ -397,13 +403,13 @@ function Order() {
                                     <th>단가</th>
                                     <th>수량</th>
                                     <th>총 금액</th>
-                                    {(isCreateMode || isEditMode) && <th style={{ width: '100px' }}>삭제</th>}
+                                    {(isCreateMode || isEditMode || isResubmitMode) && <th style={{ width: '100px' }}>삭제</th>}
                                 </tr>
                             </thead>
                             <tbody>
                                 {/* 하나의 데이터 소스를 조건에 맞게 사용 */}
                                 {customerData.customerName ? (
-                                    (isCreateMode ? products : isEditMode ? displayItemEdit : displayItems || []).map((item, index) => (
+                                    (isCreateMode ? products : isEditMode || isResubmitMode ? displayItemEdit : displayItems || []).map((item, index) => (
                                         <tr key={index}>
                                             <td>{index + 1}</td>
                                             <td>
@@ -412,7 +418,7 @@ function Order() {
                                                     className="box"
                                                     value={isCreateMode
                                                         ? item?.name || ''
-                                                        : isEditMode || isDetailView
+                                                        : isEditMode|| isResubmitMode || isDetailView
                                                             ? item?.productNm || ''
                                                             : ''}
                                                     readOnly
@@ -425,7 +431,7 @@ function Order() {
                                                         }
                                                     }}
                                                 />
-                                                {(isCreateMode || isEditMode) && (
+                                                {(isCreateMode || isEditMode || isResubmitMode ) && (
                                                     <button className="search-button" onClick={() => openProductModal(index)}>
                                                         <i className="bi bi-search"></i>
                                                     </button>
@@ -438,10 +444,10 @@ function Order() {
                                                     className="box"
                                                     value={isCreateMode
                                                         ? (item?.price !== undefined ? item.price.toLocaleString() : '')
-                                                        : isEditMode
+                                                        : isEditMode || isResubmitMode
                                                             ? (item?.orderDPrice !== undefined ? item.orderDPrice.toLocaleString() : '')
                                                             : item?.orderDPrice?.toLocaleString() || ''}
-                                                    readOnly={!isEditMode && !isCreateMode}
+                                                    readOnly={!isEditMode && !isResubmitMode && !isCreateMode}
                                                     placeholder="단가 입력"
                                                     onChange={(e) => {
                                                         // 콤마를 제거한 숫자만 추출
@@ -449,7 +455,7 @@ function Order() {
 
                                                         if (isCreateMode) {
                                                             handleProductChange(index, 'price', numericValue);
-                                                        } else if (isEditMode) {
+                                                        } else if (isEditMode || isResubmitMode) {
                                                             handleProductEdit(index, 'orderDPrice', numericValue);
                                                         }
                                                     }}
@@ -461,10 +467,10 @@ function Order() {
                                                     className="box"
                                                     value={isCreateMode
                                                         ? (item?.quantity !== undefined ? item.quantity.toLocaleString() : 0)
-                                                        : isEditMode
+                                                        : isEditMode || isResubmitMode
                                                             ? (item?.orderDQty !== undefined ? item.orderDQty.toLocaleString() : 0)
                                                             : item?.orderDQty?.toLocaleString() || 0}
-                                                    readOnly={!isEditMode && !isCreateMode}
+                                                    readOnly={!isEditMode && !isResubmitMode && !isCreateMode}
                                                     placeholder="수량 입력"
                                                     onChange={(e) => {
                                                         // 콤마를 제거한 숫자만 추출
@@ -473,7 +479,7 @@ function Order() {
                                                         // 상태 업데이트: 콤마 없는 숫자를 상태에 저장
                                                         if (isCreateMode) {
                                                             handleProductChange(index, 'quantity', numericValue);
-                                                        } else if (isEditMode) {
+                                                        } else if (isEditMode || isResubmitMode) {
                                                             handleProductEdit(index, 'orderDQty', numericValue);
                                                         }
                                                     }}
@@ -482,16 +488,16 @@ function Order() {
                                             <td>
                                                 {((isCreateMode ? (item?.price || 0) * (item?.quantity || 0) : item?.orderDPrice * item?.orderDQty) || 0).toLocaleString()}
                                             </td>
-                                            {(isCreateMode || isEditMode) && (
+                                            {(isCreateMode || isEditMode || isResubmitMode) && (
                                                 <td style={{ width: '100px' }}>
                                                     <button className="box icon del" onClick={() => {
-                                                        const currentProducts = isCreateMode ? products : isEditMode ? displayItemEdit : displayItems || [];
+                                                        const currentProducts = isCreateMode ? products : isEditMode || isResubmitMode ? displayItemEdit : displayItems || [];
                                                         // 상품이 없을 경우 알림 표시
                                                         if (currentProducts.length > 1) {
                                                             if (isCreateMode) {
                                                                 console.log("생성모드");
                                                                 removeProductRow(index);
-                                                            } else if (isEditMode) {
+                                                            } else if (isEditMode || isResubmitMode) {
                                                                 console.log("수정모드");
                                                                 removeProducteditRow(index);
                                                             }
@@ -507,7 +513,7 @@ function Order() {
                                             <td style={{ display: 'none' }}>
                                                 <input
                                                     type="text"
-                                                    value={isCreateMode ? item?.code : isEditMode ? item?.productCd : item?.productCd || ''}
+                                                    value={isCreateMode ? item?.code : isEditMode || isResubmitMode ? item?.productCd : item?.productCd || ''}
                                                     readOnly
                                                 />
                                             </td>
@@ -530,7 +536,7 @@ function Order() {
                             <tr>
                                 <td colSpan="5" style={{ textAlign: 'right', fontWeight: 'bold', padding: '12px 8px' }}>총 금액 :
                                     <span style={{ marginLeft: "5px" }}>{(
-                                        (isCreateMode ? products : isEditMode ? displayItemEdit : displayItems || [])
+                                        (isCreateMode ? products : isEditMode || isResubmitMode ? displayItemEdit : displayItems || [])
                                             .reduce((sum, item) => sum + (isCreateMode ? item?.price || 0 : item?.orderDPrice || 0) * (isCreateMode ? item?.quantity || 0 : item?.orderDQty || 0), 0)
                                     ).toLocaleString()} 원</span>
                                 </td>
@@ -539,7 +545,13 @@ function Order() {
                     )}
 
                     <div className="order-buttons">
-                        {isCreateMode && <button className="box color" onClick={handleSubmit}><i className="bi bi-floppy"></i> 주문 등록</button>}
+                        {isCreateMode && <button className="box color" onClick={handleSubmit}>주문 등록</button>}
+                        {isResubmitMode && (
+                            <button className="box color" onClick={() => handleResubmit(orderNo)}>
+                                 주문 재제출
+                            </button>
+                        )}
+
                         {isEditMode && orderHStatus === 'ing' && (<button className="box color" onClick={() => handleEdit(orderNo)}><i className="bi bi-floppy"></i> 주문 수정</button>)}
                         {isDetailView && role === 'admin' && orderHStatus === 'ing' && (
                             <>
@@ -553,6 +565,8 @@ function Order() {
                         )}
                         {isDetailView && orderHStatus === 'ing' && (
                             <button className="box color" onClick={() => window.location.href = `/order?no=${orderNo}&mode=edit`}>수정</button>)}
+                        {isDetailView && orderHStatus === 'denied' && (
+                            <button className="box color" onClick={() => window.location.href = `/order?no=${orderNo}&mode=resubmit`}>수정</button>)}
                     </div>
                 </div>
             </main>

--- a/src/main/react/components/sales/OrderHooks.js
+++ b/src/main/react/components/sales/OrderHooks.js
@@ -598,6 +598,10 @@ export const useHooksList = () => {
 
     // 반려된 주문을 다시 제출
     const handleResubmit = async (orderNo) => {
+
+        if (isSubmitting) return; // 이미 처리 중이면 중지
+        isSubmitting = true; // 처리 중 상태로 변경
+
         try {
             // 반려된 주문 정보 가져오기
             const deliveryDateElement = document.querySelector('.delivery-date');
@@ -683,6 +687,8 @@ export const useHooksList = () => {
         } catch (error) {
             console.error('주문 재제출 중 오류 발생:', error.message);
             window.showToast("주문 재제출 중 오류가 발생했습니다.", 'error');
+        }finally {
+            isSubmitting=false;
         }
     };
 


### PR DESCRIPTION
### 기능 추가: 반려된 주문을 수정하여 재결재 요청할 수 있는 기능을 구현
추가된 함수: handleResubmit(orderNo)
- 반려된 주문의 세부 정보를 가져옴
- 사용자가 관련 필드를 업데이트하고 주문을 재제출 가능
- 주문 재제출 모드(isResubmitMode)를 추가/활용하여 사용자 경험을 개선하였음.

**개선 사항: 주문 등록 시 중복 요청을 방지하기 위한 로직을 추가**
- 사용자가 주문 등록을 시도할 때, isSubmitting(Boolean)으로 하나의 요청만 처리되도록 하여 
데이터베이스에 중복 입력을 발생하지 않도록 방지함.

코드 변경:
- 재제출을 올바르게 관리하기 위해 상태 관리 및 API 호출 처리 로직을 업데이트
- 중복 요청이 시도될 경우 적절한 메시지를 표시하기 위한 에러 핸들링을 추가

<div align="center"> 

![12](https://github.com/user-attachments/assets/ff75a485-2184-4f5e-a576-5fbdbd8b9a65)

<img width="744" alt="image (1)" src="https://github.com/user-attachments/assets/1a94f2ee-e700-4c49-8cd5-a89024855d1f">


</div>

